### PR TITLE
alternative password migration for guard

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml
@@ -29,6 +29,7 @@
             <argument /> <!-- User Provider -->
             <argument /> <!-- Provider-shared Key -->
             <argument /> <!-- User Checker -->
+            <argument type="service" id="security.password_encoder" />
         </service>
 
         <service id="security.authentication.listener.guard"

--- a/src/Symfony/Component/Security/Guard/PasswordMigratingInterface.php
+++ b/src/Symfony/Component/Security/Guard/PasswordMigratingInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Guard;
+
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * The interface for all "guard" authenticators required to hook-in the password migration process.
+ *
+ * @author Roland Franssen <franssen.roland@gmail.com>
+ */
+interface PasswordMigratingInterface
+{
+    /**
+     * @param mixed The user credentials
+     */
+    public function migratePassword(UserInterface $user, $credentials, PasswordUpgraderInterface $passwordUpgrader, UserPasswordEncoderInterface $passwordEncoder);
+}

--- a/src/Symfony/Component/Security/Guard/PasswordMigratingInterface.php
+++ b/src/Symfony/Component/Security/Guard/PasswordMigratingInterface.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * The interface for all "guard" authenticators required to hook-in the password migration process.
+ * The interface for all "guard" authenticators to automatically hook-in the password migration process.
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
  */

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -118,7 +118,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         if (true !== $guardAuthenticator->checkCredentials($token->getCredentials(), $user)) {
             throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true.', \get_class($guardAuthenticator)));
         }
-        if ($this->userProvider instanceof PasswordUpgraderInterface && $guardAuthenticator instanceof PasswordMigratingInterface && method_exists($this->passwordEncoder, 'needsRehash') && $this->passwordEncoder->needsRehash($user, $user->getPassword())) {
+        if ($this->userProvider instanceof PasswordUpgraderInterface && $guardAuthenticator instanceof PasswordMigratingInterface && method_exists($this->passwordEncoder, 'needsRehash') && $this->passwordEncoder->needsRehash($user)) {
             $guardAuthenticator->migratePassword($user, $token->getCredentials(), $this->userProvider, $this->passwordEncoder);
         }
         $this->userChecker->checkPostAuth($user);

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -118,7 +118,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         if (true !== $guardAuthenticator->checkCredentials($token->getCredentials(), $user)) {
             throw new BadCredentialsException(sprintf('Authentication failed because %s::checkCredentials() did not return true.', \get_class($guardAuthenticator)));
         }
-        if ($this->userProvider instanceof PasswordUpgraderInterface && $guardAuthenticator instanceof PasswordMigratingInterface) {
+        if ($this->userProvider instanceof PasswordUpgraderInterface && $guardAuthenticator instanceof PasswordMigratingInterface && method_exists($this->passwordEncoder, 'needsRehash') && $this->passwordEncoder->needsRehash($user, $user->getPassword())) {
             $guardAuthenticator->migratePassword($user, $token->getCredentials(), $this->userProvider, $this->passwordEncoder);
         }
         $this->userChecker->checkPostAuth($user);


### PR DESCRIPTION
the implementation could look like

```php
public function migratePassword(
    UserInterface $user,
    $credentials,
    PasswordUpgraderInterface $passwordUpgrader,
    UserPasswordEncoderInterface $passwordEncoder
) {
    $passwordUpgrader->upgradePassword(
        $user,
        $passwordEncoder->encodePassword($user, $credentials['password'])
    );
}
```

