### PR TITLE
 [VarExporter] Initialize lazy objects when setting a property 

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -61,7 +61,7 @@ class LazyObjectRegistry
         }
 
         foreach ($propertyScopes as $key => [$scope, $name, $readonlyScope]) {
-            $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = null !== $readonlyScope ? $name : null;
+            $propertyScopes[$k = "\0$scope\0$name"] ?? $propertyScopes[$k = "\0*\0$name"] ?? $k = $name;
 
             if ($k === $key && "\0$class\0lazyObjectId" !== $k) {
                 $classProperties[$readonlyScope ?? $scope][$name] = $key;
@@ -146,6 +146,6 @@ class LazyObjectRegistry
             return null;
         }
 
-        return $scope;
+        return \ReflectionProperty::class === $scope ? $class : $scope;
     }
 }

--- a/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
+++ b/src/Symfony/Component/VarExporter/Internal/LazyObjectRegistry.php
@@ -134,13 +134,17 @@ class LazyObjectRegistry
         return $methods;
     }
 
-    public static function getScope($propertyScopes, $class, $property, $readonlyScope = null)
+    public static function getScope($propertyScopes, $class, $property, $readonlyScope = null, &$scope = null)
     {
+        if (5 <= \func_num_args()) {
+            $scope = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['class'] ?? \Closure::class;
+        }
+
         if (null === $readonlyScope && !isset($propertyScopes["\0$class\0$property"]) && !isset($propertyScopes["\0*\0$property"])) {
             return null;
         }
 
-        $scope = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['class'] ?? \Closure::class;
+        $scope ??= debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 3)[2]['class'] ?? \Closure::class;
 
         if (null === $readonlyScope && isset($propertyScopes["\0*\0$property"]) && ($class === $scope || is_subclass_of($class, $scope))) {
             return null;

--- a/src/Symfony/Component/VarExporter/LazyGhostTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyGhostTrait.php
@@ -192,10 +192,17 @@ trait LazyGhostTrait
         $state = null;
 
         if ([$class, , $readonlyScope] = $propertyScopes[$name] ?? null) {
-            $scope = Registry::getScope($propertyScopes, $class, $name, $readonlyScope);
+            $scope = Registry::getScope($propertyScopes, $class, $name, $readonlyScope, $realScope);
 
             $state = Registry::$states[$this->lazyObjectId ?? ''] ?? null;
+
             if ($state && ($readonlyScope === $scope || isset($propertyScopes["\0$scope\0$name"]))) {
+                if (\ReflectionProperty::class !== $realScope
+                    && ($state->status || $state->initialize($this, null, null))
+                    && LazyObjectState::STATUS_UNINITIALIZED_FULL === $state->status
+                ) {
+                    $state->initialize($this, $name, $readonlyScope ?? $scope);
+                }
                 goto set_in_scope;
             }
         }

--- a/src/Symfony/Component/VarExporter/LazyProxyTrait.php
+++ b/src/Symfony/Component/VarExporter/LazyProxyTrait.php
@@ -25,15 +25,15 @@ trait LazyProxyTrait
     /**
      * @param \Closure():object $initializer Returns the proxied object
      */
-    public static function createLazyProxy(\Closure $initializer): static
+    public static function createLazyProxy(\Closure $initializer, self $instance = null): static
     {
-        if (self::class !== $class = static::class) {
+        if (self::class !== $class = $instance ? $instance::class : static::class) {
             $skippedProperties = ["\0".self::class."\0lazyObjectId" => true];
         } elseif (\defined($class.'::LAZY_OBJECT_PROPERTY_SCOPES')) {
             Hydrator::$propertyScopes[$class] ??= $class::LAZY_OBJECT_PROPERTY_SCOPES;
         }
 
-        $instance = (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        $instance ??= (Registry::$classReflectors[$class] ??= new \ReflectionClass($class))->newInstanceWithoutConstructor();
         $instance->lazyObjectId = $id = spl_object_id($instance);
         Registry::$states[$id] = new LazyObjectState($initializer);
 

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/LazyClass.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/LazyGhost/LazyClass.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost;
+
+use Symfony\Component\VarExporter\LazyGhostTrait;
+
+class LazyClass
+{
+    use LazyGhostTrait {
+        createLazyGhost as private;
+    }
+
+    private int $lazyObjectId;
+    public int $public;
+
+    public function __construct(\Closure $initializer)
+    {
+        self::createLazyGhost($initializer, [], $this);
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyGhostTraitTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\VarExporter\Internal\LazyObjectRegistry;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildMagicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildStdClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\ChildTestClass;
+use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\LazyClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\MagicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyGhost\TestClass;
 
@@ -204,11 +205,12 @@ class LazyGhostTraitTest extends TestCase
         $this->assertSame(["\0".TestClass::class."\0lazyObjectId"], array_keys((array) $instance));
         $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
-        $this->assertTrue($instance->isLazyObjectInitialized());
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(["\0".TestClass::class."\0lazyObjectId", 'public'], array_keys((array) $instance));
         $this->assertSame(1, $counter);
 
         $instance->initializeLazyObject();
+        $this->assertTrue($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
         $this->assertSame(6, $counter);
 
@@ -225,11 +227,12 @@ class LazyGhostTraitTest extends TestCase
             return 234;
         });
 
-        $instance->public = 123;
+        $r = new \ReflectionProperty($instance, 'public');
+        $r->setValue($instance, 123);
 
         $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(234, $instance->publicReadonly);
-        $this->assertTrue($instance->isLazyObjectInitialized());
+        $this->assertFalse($instance->isLazyObjectInitialized());
         $this->assertSame(123, $instance->public);
 
         $this->assertTrue($instance->resetLazyObject());
@@ -265,5 +268,12 @@ class LazyGhostTraitTest extends TestCase
 
         $instance->public = 12;
         $this->assertSame(12, $instance->public);
+    }
+
+    public function testLazyClass()
+    {
+        $obj = new LazyClass(fn ($proxy) => $proxy->public = 123);
+
+        $this->assertSame(123, $obj->public);
     }
 }

--- a/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/LazyProxyTraitTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarExporter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarExporter\LazyProxyTrait;
 use Symfony\Component\VarExporter\ProxyHelper;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\FinalPublicClass;
 use Symfony\Component\VarExporter\Tests\Fixtures\LazyProxy\ReadOnlyClass;
@@ -239,6 +240,25 @@ class LazyProxyTraitTest extends TestCase
         $proxy = $this->createLazyProxy(ReadOnlyClass::class, fn () => new ReadOnlyClass(123));
 
         $this->assertSame(123, $proxy->foo);
+    }
+
+    public function testLazyDecoratorClass()
+    {
+        $obj = new class() extends TestClass {
+            use LazyProxyTrait {
+                createLazyProxy as private;
+            }
+
+            private int $lazyObjectId;
+            private parent $lazyObjectReal;
+
+            public function __construct()
+            {
+                self::createLazyProxy(fn() => new TestClass((object) ['foo' => 123]), $this);
+            }
+        };
+
+        $this->assertSame(['foo' => 123], (array) $obj->getDep());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Doctrine relies on that behavior. Would be great to rework Doctrine instead but for now this allows experimenting with using VarExporter in Doctrine. This could be turned into an option before merge.